### PR TITLE
redeclaration error

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -21,10 +21,3 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 }
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,11 +26,12 @@ dependencies {
     compile project(':annotations')
 }
 
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+sourceSets {
+    main {
+        kotlin {
+            exclude '**/TargetClass.kt'
+        }
+    }
 }
 
 apply plugin: 'idea'

--- a/app/src/main/java/kategory/io/TargetClass.kt
+++ b/app/src/main/java/kategory/io/TargetClass.kt
@@ -4,4 +4,7 @@ package kategory.io
  * This would be a class written by the user that we are gonna replace with an instance
  * generated at compile time.
  */
-class TargetClass
+class TargetClass {
+
+    fun x(@implicit a: String) = a
+}

--- a/app/src/main/java/kategory/io/TargetClass.kt
+++ b/app/src/main/java/kategory/io/TargetClass.kt
@@ -1,0 +1,7 @@
+package kategory.io
+
+/**
+ * This would be a class written by the user that we are gonna replace with an instance
+ * generated at compile time.
+ */
+class TargetClass

--- a/app/src/main/java/kategory/io/TestClass.kt
+++ b/app/src/main/java/kategory/io/TestClass.kt
@@ -1,8 +1,6 @@
 package kategory.io
 
-fun x(@implicit a: String) = a
-
 class Whatever {
 
-    val generatedClassInstance = TargetClass("any name")
+    val generatedClassInstance = TargetClass("any name").generatedFunction()
 }

--- a/app/src/main/java/kategory/io/TestClass.kt
+++ b/app/src/main/java/kategory/io/TestClass.kt
@@ -4,5 +4,5 @@ fun x(@implicit a: String) = a
 
 class Whatever {
 
-    val generatedClassInstance = MyGeneratedClass("any name")
+    val generatedClassInstance = TargetClass("any name")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,3 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 }
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}

--- a/compile-time/build.gradle
+++ b/compile-time/build.gradle
@@ -34,10 +34,3 @@ dependencies {
     testCompile fileTree(dir: './src/test/libs', includes: ['*.jar'])
     testCompile files(Jvm.current().getToolsJar())
 }
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}

--- a/compile-time/src/main/java/kategory/io/ImplicitsProcessor.kt
+++ b/compile-time/src/main/java/kategory/io/ImplicitsProcessor.kt
@@ -1,7 +1,6 @@
 package kategory.io
 
 import kategory.io.generation.FileGenerator
-import kategory.io.messager.log
 import kategory.io.messager.logMW
 import java.io.File
 import javax.annotation.processing.AbstractProcessor
@@ -19,6 +18,7 @@ class ImplicitsProcessor : AbstractProcessor() {
 
     override fun process(annotations: MutableSet<out TypeElement>?, roundEnv: RoundEnvironment): Boolean {
         processingEnv.messager.logMW("Implicits processor running...")
+        val fileGenerator = FileGenerator()
         roundEnv.getElementsAnnotatedWith(implicit::class.java)
                 .forEach {
                     processingEnv.messager.logMW("Implicit annotated class found: " + it.simpleName)
@@ -27,8 +27,9 @@ class ImplicitsProcessor : AbstractProcessor() {
                     if (!kaptGeneratedDir.parentFile.exists()) {
                         kaptGeneratedDir.parentFile.mkdirs()
                     }
-                    val fileGenerator = FileGenerator()
-                    val kotlinFile = fileGenerator.createKotlinFile()
+
+                    val elementPackage = processingEnv.elementUtils.getPackageOf(it).qualifiedName
+                    val kotlinFile = fileGenerator.createKotlinFile(elementPackage)
                     kotlinFile.writeTo(kaptGeneratedDir)
                 }
         return false

--- a/compile-time/src/main/java/kategory/io/ImplicitsProcessor.kt
+++ b/compile-time/src/main/java/kategory/io/ImplicitsProcessor.kt
@@ -8,6 +8,7 @@ import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 
+
 class ImplicitsProcessor : AbstractProcessor() {
 
     override fun getSupportedSourceVersion(): SourceVersion {
@@ -21,12 +22,15 @@ class ImplicitsProcessor : AbstractProcessor() {
         val fileGenerator = FileGenerator()
         roundEnv.getElementsAnnotatedWith(implicit::class.java)
                 .forEach {
-                    processingEnv.messager.logMW("Implicit annotated class found: " + it.simpleName)
+                    processingEnv.messager.logMW("Implicit annotated element found: " + it.simpleName)
 
                     val kaptGeneratedDir = File(processingEnv.options["kapt.kotlin.generated"])
                     if (!kaptGeneratedDir.parentFile.exists()) {
                         kaptGeneratedDir.parentFile.mkdirs()
                     }
+
+                    val rootProjectDir = File(".").canonicalPath
+                    processingEnv.messager.logMW("root project:" + rootProjectDir)
 
                     val elementPackage = processingEnv.elementUtils.getPackageOf(it).qualifiedName
                     val kotlinFile = fileGenerator.createKotlinFile(elementPackage)

--- a/compile-time/src/main/java/kategory/io/generation/FileGenerator.kt
+++ b/compile-time/src/main/java/kategory/io/generation/FileGenerator.kt
@@ -1,14 +1,15 @@
 package kategory.io.generation
 
 import com.squareup.kotlinpoet.*
+import javax.lang.model.element.Name
 
 /**
  * Generate some Kotlin sample files using KotlinPoet.
  */
 class FileGenerator {
 
-    fun createKotlinFile(): KotlinFile {
-        return KotlinFile.builder("kategory.io", "TargetClass")
+    fun createKotlinFile(elementPackage: Name): KotlinFile {
+        return KotlinFile.builder(elementPackage.toString(), "TargetClass")
                 .addType(TypeSpec.classBuilder("TargetClass")
                         .primaryConstructor(FunSpec.constructorBuilder()
                                 .addParameter("name", String::class)

--- a/compile-time/src/main/java/kategory/io/generation/FileGenerator.kt
+++ b/compile-time/src/main/java/kategory/io/generation/FileGenerator.kt
@@ -8,8 +8,8 @@ import com.squareup.kotlinpoet.*
 class FileGenerator {
 
     fun createKotlinFile(): KotlinFile {
-        return KotlinFile.builder("kategory.io", "MyGeneratedClass")
-                .addType(TypeSpec.classBuilder("MyGeneratedClass")
+        return KotlinFile.builder("kategory.io", "TargetClass")
+                .addType(TypeSpec.classBuilder("TargetClass")
                         .primaryConstructor(FunSpec.constructorBuilder()
                                 .addParameter("name", String::class)
                                 .build())


### PR DESCRIPTION
After achieving Kotlin code generation and referentiation from client code without compile time errors (everything is on `master` branch), I tried to generate a class with the same name and into the same package of an already existent one from client code. That would be a possible approach to rewrite classes with just our required changes. But when trying to do so, I face a quite obvious error:
```
:app:compileKotlin
Using kotlin incremental compilation
e: /Users/jorgecastillo/IdeaProjects/implicits/app/build/generated/source/kaptKotlin/main/kategory/io/TargetClass.kt: (5, 7): Redeclaration: TargetClass
e: /Users/jorgecastillo/IdeaProjects/implicits/app/src/main/java/kategory/io/TargetClass.kt: (7, 7): Redeclaration: TargetClass
:app:compileKotlin FAILED
```

The compiler is clearly detecting the class duplicity and failing to compile. You get the class properly generated and both classes exist, but both are underlined in red and you can't compile your  client project.